### PR TITLE
Data processing of large file with Arrow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^kew_metrics\.Rproj$
 ^\.Rproj\.user$
+^\.gitattributes$
 ^app\.R$
 ^LICENSE\.md$
 ^rsconnect/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: MIT + file LICENSE
 Depends:
     R (>= 3.5.0)
 Imports: 
+    arrow (>= 5.0.0),
     bslib (>= 0.9.0),
     dplyr,
     DT,

--- a/R/mod_01_diversity.R
+++ b/R/mod_01_diversity.R
@@ -18,9 +18,10 @@ diversity_ui <- function(id) {
               label = "Select layer:",
               choices = list(
                 "None" = "",
-                "Gymnosperms" = "gymno",
-                "Ferns" = "ferns",
-                "Angiosperms" = "angio"
+                "Gymnosperms" = "Gymnosperms",
+                "Ferns" = "Ferns",
+                "Angiosperms" = "Angiosperms",
+                "Lycophytes" = "Lycophytes"
               ),
               selected = ""
             )
@@ -40,7 +41,11 @@ diversity_ui <- function(id) {
           )
         )
       ),
-      uiOutput(ns("diversity_conditional"))
+      shiny::conditionalPanel(
+        "input.species_layer != ''",
+        ns = ns,
+        species_richness_ui(id = ns("species_richness"))
+      )
     )
   )
 }
@@ -61,5 +66,12 @@ diversity_server <- function(id) {
         updateSelectInput(session, "species_layer", selected = "")
       }
     })
+
+    chosen_species <- reactive({
+      shiny::req(input$species_layer)
+      input$species_layer
+    })
+
+    species_richness_server(id = "species_richness", species = chosen_species)
   })
 }

--- a/R/mod_01_diversity_species_richness.R
+++ b/R/mod_01_diversity_species_richness.R
@@ -54,11 +54,11 @@ species_richness_server <- function(id, species) {
     })
 
     get_unique_column_values <- function(.data, column) {
-      .data |>
-        dplyr::distinct({{ column }}) |>
-        dplyr::collect() |>
-        dplyr::pull() |>
-        as.character() |>
+      .data %>%
+        dplyr::distinct({{ column }}) %>%
+        dplyr::collect() %>%
+        dplyr::pull() %>%
+        as.character() %>%
         sort(decreasing = FALSE)
     }
 
@@ -135,8 +135,8 @@ species_richness_server <- function(id, species) {
     )
 
     table_data <- shiny::reactive({
-      filtered_data() |>
-        dplyr::select(!!table_columns) |>
+      filtered_data() %>%
+        dplyr::select(!!table_columns) %>%
         dplyr::collect()
     })
 
@@ -145,10 +145,10 @@ species_richness_server <- function(id, species) {
     # Example: Diversity by country ----
     # Number of distinct taxon names that appear for each country.
     taxon_by_country_count <- shiny::reactive({
-      filtered_data() |>
-        dplyr::group_by(.data$continent, .data$region, .data$area) |>
-        dplyr::summarise(taxon_count = dplyr::n_distinct(.data$taxon_name)) |>
-        dplyr::arrange(dplyr::desc(.data$taxon_count)) |>
+      filtered_data() %>%
+        dplyr::group_by(.data$continent, .data$region, .data$area) %>%
+        dplyr::summarise(taxon_count = dplyr::n_distinct(.data$taxon_name)) %>%
+        dplyr::arrange(dplyr::desc(.data$taxon_count)) %>%
         dplyr::collect()
     })
 

--- a/R/mod_01_diversity_species_richness.R
+++ b/R/mod_01_diversity_species_richness.R
@@ -1,0 +1,157 @@
+species_richness_ui <- function(id) {
+  ns <- NS(id)
+  page_fillable(
+    navset_card_tab(
+      sidebar = sidebar(
+        selectizeInput(
+          inputId = ns("family"),
+          label = "Select family",
+          choices = NULL,
+          multiple = TRUE
+        ),
+        selectizeInput(
+          inputId = ns("genus"),
+          label = "Select genus",
+          choices = NULL,
+          multiple = TRUE
+        ),
+        selectizeInput(
+          inputId = ns("taxon_name"),
+          label = "Select taxon name",
+          choices = NULL,
+          multiple = TRUE
+        ),
+        input_task_button(
+          id = ns("set_filter"),
+          label = "Apply Filter"
+        )
+      ),
+      full_screen = TRUE,
+      title = "Species Diversity",
+      tab_datatable_ui(id = ns("filtered_table"), title = "Table"),
+      tab_datatable_ui(id = ns("taxon_by_country_count"), title = "Taxon count")
+      # TODO: Create an about page.
+      # nav_panel("About", includeMarkdown(system.file("about", "about_species_richness.Rmd",
+      #                                                package = "kew.metrics"
+    )
+  )
+}
+
+species_richness_server <- function(id, species) {
+  moduleServer(id, function(input, output, session) {
+    stopifnot(shiny::is.reactive(species))
+
+    # Load EDGE data files ----
+    all_species_data <- arrow::open_dataset(
+      sources = system.file("01_data", "Diversity", "species_richness",
+                            package = "kew.metrics", mustWork = TRUE),
+      format = "parquet"
+    )
+
+    species_data <- reactive({
+      req(species())
+      dplyr::filter(all_species_data, .data$higher == .env$species())
+    })
+
+    get_unique_column_values <- function(.data, column) {
+      .data |>
+        dplyr::distinct({{ column }}) |>
+        dplyr::collect() |>
+        dplyr::pull() |>
+        as.character() |>
+        sort(decreasing = FALSE)
+    }
+
+    # Set filters for diversity ----
+    observe({
+      shiny::updateSelectizeInput(
+        session = session,
+        inputId = "family",
+        choices = get_unique_column_values(species_data(), .data$family),
+        server = FALSE
+      )
+      updateSelectizeInput(
+        session = session,
+        inputId = "genus",
+        choices = get_unique_column_values(species_data(), .data$genus),
+        server = TRUE
+      )
+      updateSelectizeInput(
+        session = session,
+        inputId = "taxon_name",
+        choices = get_unique_column_values(species_data(), .data$taxon_name),
+        server = TRUE
+      )
+    })
+
+    # Refine filters based on the other filters ----
+    # Update genus options based on family ----
+    filtered_by_family <- reactive({
+      filter_if_truthy(.data = species_data(), col = .data$family, ifTruthy = input$family)
+    })
+
+    observe({
+      updateSelectizeInput(
+        session,
+        "genus",
+        choices = get_unique_column_values(filtered_by_family(), .data$genus),
+        selected = character(0)
+      )
+    }) %>%
+      bindEvent(input$family, ignoreNULL = TRUE, ignoreInit = TRUE)
+
+    ## Update genus options based on group and family ----
+    filtered_by_genus <- reactive({
+      filter_if_truthy(filtered_by_family(), .data$genus, input$genus)
+    })
+
+    observe({
+      updateSelectizeInput(
+        session,
+        "edge_genus_select",
+        choices = get_unique_column_values(filtered_by_genus(), .data$taxon_name),
+        selected = character(0)
+      )
+    }) %>%
+      bindEvent(c(input$family, input$genus), ignoreNULL = TRUE, ignoreInit = TRUE)
+
+    # Create filtered_edge_data reactive that responds to the apply_edge_filter button ----
+    filtered_data <- reactive({
+      filter_if_truthy(filtered_by_genus(), .data$taxon_name, input$taxon_name)
+    }) %>%
+      bindEvent(input$set_filter)
+
+    # species datatable ----
+    table_columns <- c(
+      "powo_id",
+      "family",
+      "genus",
+      "species",
+      "taxon_name",
+      "taxon_authors",
+      "geographic_area",
+      "accepted_plant_name_id",
+      "higher"
+    )
+
+    table_data <- shiny::reactive({
+      filtered_data() |>
+        dplyr::select(!!table_columns) |>
+        dplyr::collect()
+    })
+
+    tab_datatable_server(id = "filtered_table", .data = table_data)
+
+    # Example: Diversity by country ----
+    # Number of distinct taxon names that appear for each country.
+    taxon_by_country_count <- shiny::reactive({
+      filtered_data() |>
+        dplyr::group_by(.data$continent, .data$region, .data$area) |>
+        dplyr::summarise(taxon_count = dplyr::n_distinct(.data$taxon_name)) |>
+        dplyr::arrange(dplyr::desc(.data$taxon_count)) |>
+        dplyr::collect()
+    })
+
+    tab_datatable_server(id = "taxon_by_country_count", .data = taxon_by_country_count)
+  })
+}

--- a/inst/02_data_prep/diversity_species_richness_data_prep.R
+++ b/inst/02_data_prep/diversity_species_richness_data_prep.R
@@ -1,0 +1,76 @@
+library(arrow)
+library(dplyr)
+library(rWCVP)
+
+tm <- rWCVP::taxonomic_mapping %>%
+  mutate(across(everything(), factor))
+
+# full list of names
+names <- rWCVPdata::wcvp_names
+
+# Convert data types of some columns
+names <- dplyr::mutate(
+  names,
+  across(
+    c(taxon_rank:infraspecies, lifeform_description, climate_description, reviewed),
+    factor
+  ),
+  across(ends_with("plant_name_id"), as.integer)
+) %>%
+  left_join(tm, by = "family")
+
+# but we only want Accepted species
+acc_names <- dplyr::filter(names, taxon_status == "Accepted")
+
+# for each species we have distribution data
+distributions <- rWCVPdata::wcvp_distributions
+
+get_levels <- function(.data, col) {
+  dplyr::distinct(distributions, dplyr::across(dplyr::starts_with({{ col }}))) %>%
+    dplyr::arrange(dplyr::across(dplyr::contains("_code_"))) %>%
+    dplyr::pull()
+}
+
+continent_levels <- get_levels(distributions, "continent")
+region_levels <- get_levels(distributions, "region")
+area_levels <- get_levels(distributions, "area")
+
+distributions <- dplyr::mutate(
+  distributions,
+  across(ends_with("_id"), as.integer),
+  across(introduced:location_doubtful, as.logical),
+  continent = factor(continent, levels = continent_levels),
+  region = factor(region, levels = region_levels),
+  area = factor(area, levels = area_levels)
+)
+
+# it should just be a left join to link the native ranges – same system in the EDGE maps
+acc_names2 <- left_join(acc_names, rWCVPdata::wcvp_distributions,
+                        by = c("accepted_plant_name_id" = "plant_name_id")) %>%
+  filter(!introduced, !extinct, !location_doubtful)
+
+# TODO: Use dplyr::select() to get rid of any columns we won't need in the app. This will make the
+# stored data files smaller, and easier to deploy and host.
+
+# Store this file to parquet
+write_dataset(
+  dataset = acc_names2,
+  path = system.file("01_data", "Diversity", "species_richness", package = "kew.metrics"),
+  format = "parquet",
+  partitioning = "higher"
+)
+
+# To read a dataset back
+this_data <- arrow::open_dataset(
+  sources = system.file("01_data", "Diversity", "species_richness",
+                        package = "kew.metrics", mustWork = TRUE),
+  format = "parquet"
+)
+
+# Then use collect() to denote when to pull the data into R
+# for example:
+this_data %>%
+  dplyr::group_by(.data$higher) %>%
+  dplyr::count(.data$area) %>%
+  dplyr::arrange(dplyr::desc(.data$n)) %>%
+  dplyr::collect()


### PR DESCRIPTION
This contains an example of one of the largest files that the app is expected to have to deal with.

Due to limitations in the use of Git LFS on public forked repos, I can't add the parquet files directly, but you can generate them locally by running the _inst/02_data_prep/diversity_species_richness_data_prep.R_ script up to line 62. After line 62 is a demo of how to query for summary data efficiently using the connection to the arrow dataset, but without loading in the 600MB+ of raw data into the R session.
On line 52, there is also a note to say we should remove any unnecessary columns from the data before storing, to reduce the storage requirements further.

One of the concerns is that shinyapps.io has a 1GB deployment image cap, which we could hit with large datasets like this bundled into the image. At which point, we may need to have some external storage/database to link to. Swapping to a database should require minimal code changes if we use dbplyr - we just swap out the call to an Arrow dataset with a database connection, but means paying for some storage solution that we can use.

The _R/mod_01_diversity_species_richness.R_ is just a demo of how a page of the app might be set up to show 2 tables of results based on the filtered arrow data. Some of the filters can take a moment to populate if there are a lot of options - it could do with some form of CSS loader to denote that things are recomputing where this happens. But one of the key tricks is to leave the `collect()` operation as late as possible.